### PR TITLE
Config file to filter attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-dockerdog
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+bin/dockerdog: *.go
+	go build -o $@ .

--- a/config.json
+++ b/config.json
@@ -1,0 +1,37 @@
+{
+  "attributes": {
+    "image": true
+  },
+  "events": {
+    "image": {
+      "actions": {
+        "pull": {},
+        "delete": {}
+      }
+    },
+    "container": {
+      "actions": {
+        "create": {},
+        "start": {},
+        "stop": {},
+        "attach": {},
+        "detach": {},
+        "destroy": {},
+        "exec_create": {},
+        "exec_detach": {},
+        "exec_start": {},
+        "die": {
+          "attributes": {
+            "exitCode": true
+          }
+        },
+        "kill": {
+          "attributes": {
+            "signal": true
+          }
+        },
+        "oom": {}
+      }
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,49 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"os"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/fsouza/go-dockerclient"
 )
+
+// config represents a config file that controls what events and actions to
+// track.
+type config struct {
+	Attributes map[string]bool `json:"attributes"`
+
+	Events map[string]struct {
+		Actions map[string]struct {
+			Attributes map[string]bool `json:"attributes"`
+		} `json:"actions"`
+	} `json:"events"`
+}
+
+func (c *config) attributes(event, action string) map[string]bool {
+	attributes := make(map[string]bool)
+	for k, v := range c.Attributes {
+		attributes[k] = v
+	}
+	if e, ok := c.Events[event]; ok {
+		if a, ok := e.Actions[action]; ok {
+			for k, v := range a.Attributes {
+				attributes[k] = v
+			}
+		}
+	}
+	return attributes
+}
+
+func loadConfig(r io.Reader) (*config, error) {
+	var c config
+	err := json.NewDecoder(r).Decode(&c)
+	return &c, err
+}
 
 var supportedEventTypes = map[string]bool{
 	"container": true,
@@ -17,40 +53,64 @@ var supportedEventTypes = map[string]bool{
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	var (
 		statsdAddr = flag.String("statsd", "localhost:8126", "Address of statsd")
 	)
+	flag.Parse()
+	args := flag.Args()
+	var r io.Reader = os.Stdin
+	if len(args) > 0 {
+		f, err := os.Open(args[0])
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		r = f
+	}
+
+	config, err := loadConfig(r)
+	if err != nil {
+		return fmt.Errorf("error loading config: %v", err)
+	}
 
 	s, err := statsd.New(*statsdAddr)
 	if err != nil {
-		log.Fatal(fmt.Errorf("could not connect to statsd: %v", err))
+		return fmt.Errorf("could not connect to statsd: %v", err)
 	}
 	defer s.Close()
 
 	d, err := docker.NewClientFromEnv()
 	if err != nil {
-		log.Fatal(fmt.Errorf("could not connect to Docker daemon: %v", err))
+		return fmt.Errorf("could not connect to Docker daemon: %v", err)
 	}
 
-	if err := watch(d, s); err != nil {
-		log.Fatal(err)
-	}
+	return watch(config, d, s)
 }
 
-func watch(c *docker.Client, s *statsd.Client) error {
+func watch(config *config, c *docker.Client, s *statsd.Client) error {
 	events := make(chan *docker.APIEvents)
 	if err := c.AddEventListener(events); err != nil {
 		return fmt.Errorf("could not subscribe event listener: %v", err)
 	}
 
 	for event := range events {
-		if !supportedEventTypes[event.Type] {
+		if _, ok := config.Events[event.Type]; !ok {
 			continue
 		}
 
+		enabledAttributes := config.attributes(event.Type, event.Action)
+
 		var tags []string
 		for k, v := range event.Actor.Attributes {
-			tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+			if enabledAttributes[k] {
+				tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+			}
 		}
 
 		s.Count(fmt.Sprintf("docker.events.%s.%s", event.Type, event.Action), 1, tags, 1)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_Attributes(t *testing.T) {
+	config := testConfig(t)
+
+	assert.Equal(t, map[string]bool{"image": true}, config.attributes("container", "start"))
+	assert.Equal(t, map[string]bool{"image": false}, config.attributes("container", "create"))
+	assert.Equal(t, map[string]bool{"image": true, "exitCode": true}, config.attributes("container", "die"))
+	assert.Equal(t, map[string]bool{"image": true, "signal": true}, config.attributes("container", "kill"))
+}
+
+const testConfigJson = `{
+  "attributes": {
+    "image": true
+  },
+  "events": {
+    "image": {
+      "actions": {
+        "pull": {},
+        "delete": {}
+      }
+    },
+    "container": {
+      "actions": {
+        "create": {
+          "attributes": {
+            "image": false
+          }
+	},
+        "start": {},
+        "die": {
+          "attributes": {
+            "exitCode": true
+          }
+        },
+        "kill": {
+          "attributes": {
+            "signal": true
+          }
+        }
+      }
+    }
+  }
+}`
+
+func testConfig(t testing.TB) *config {
+	config, err := loadConfig(strings.NewReader(testConfigJson))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return config
+}


### PR DESCRIPTION
This adds a config file format that allows to you granularly filter what events you want to track, and the attributes of those events.