### PR TITLE
CloudWatch Events output

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -1,0 +1,142 @@
+package cloudwatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/remind101/dockerdog/config"
+)
+
+const (
+	// Source is the value that will be used in the "Source" of the
+	// PutEventRequestEntry.
+	Source = "docker"
+
+	// The maximum number of PutEventsRequestEntries per PutEvents API
+	// call.
+	MaxEntries = 10
+
+	// Number of PutEvents requests to buffer before applying back pressure.
+	PutEventsBuffer = 100
+)
+
+// Detail represents the structure of the `Detail` field we send in the
+// PutEvents request.
+type Detail struct {
+	// Event is the raw Docker event.
+	Event *docker.APIEvents `json:"event"`
+}
+
+type cloudwatcheventsClient interface {
+	PutEvents(*cloudwatchevents.PutEventsInput) (*cloudwatchevents.PutEventsOutput, error)
+}
+
+type Worker struct {
+	config *config.Config
+
+	// events is where the worker will pull events from.
+	events chan *docker.APIEvents
+
+	// cloudwatch is the CloudWatch Events client that will be used to
+	// PutEvents.
+	cloudwatch cloudwatcheventsClient
+}
+
+func NewWorker(config *config.Config, events chan *docker.APIEvents) *Worker {
+	cloudwatch := cloudwatchevents.New(session.New())
+
+	return &Worker{
+		config:     config,
+		events:     events,
+		cloudwatch: cloudwatch,
+	}
+}
+
+func (w *Worker) Run() error {
+	// The Docker event consumer will send PutEventsInput's that are ready
+	// to be flushed to this channel.
+	var (
+		flush  = make(chan *cloudwatchevents.PutEventsInput, PutEventsBuffer)
+		closed bool
+	)
+
+	// Represents our current buffer of PutEventsRequestEntries. When this
+	// has reached 10 Entries, it will be flushed to the channel above.
+	var input *cloudwatchevents.PutEventsInput
+
+	for {
+		select {
+		case input, ok := <-flush:
+			if !ok {
+				log.Println("cloudwatch: All inputs flushed")
+				// Channel is fully flushed and closed, return.
+				return nil
+			}
+
+			_, err := w.cloudwatch.PutEvents(input)
+			if err != nil {
+				return err
+			}
+		case event, ok := <-w.events:
+			if !ok {
+				if !closed {
+					if input != nil {
+						flush <- input
+					}
+
+					// If the docker events channel has been
+					// closed, we close the flush channel so
+					// that we can flush all buffered inputs
+					// before exiting.
+					close(flush)
+					closed = true
+					log.Println("cloudwatch: Closing flush channel")
+				}
+				continue
+			}
+
+			if _, ok := w.config.Events[event.Type]; !ok {
+				continue
+			}
+
+			raw, err := json.Marshal(&Detail{
+				Event: event,
+			})
+			if err != nil {
+				return err
+			}
+
+			if input == nil {
+				input = new(cloudwatchevents.PutEventsInput)
+			}
+
+			input.Entries = append(input.Entries, &cloudwatchevents.PutEventsRequestEntry{
+				Source:     aws.String("docker"),
+				DetailType: aws.String(fmt.Sprintf("%s.%s", event.Type, event.Action)),
+				Detail:     aws.String(string(raw)),
+				Time:       aws.Time(time.Unix(0, event.TimeNano)),
+			})
+
+			if len(input.Entries) == MaxEntries {
+				select {
+				case flush <- input:
+				default:
+					log.Println("cloudwatch: Dropping %d events", len(input.Entries))
+				}
+				input = nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func Watch(config *config.Config, events chan *docker.APIEvents) error {
+	return NewWorker(config, events).Run()
+}

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -1,0 +1,73 @@
+package cloudwatch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/remind101/dockerdog/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorker_ClosedChannel(t *testing.T) {
+	config := newConfig(t)
+	events := make(chan *docker.APIEvents)
+	close(events)
+	c := new(mockCloudWatchEventsClient)
+	w := &Worker{
+		config:     config,
+		events:     events,
+		cloudwatch: c,
+	}
+
+	err := w.Run()
+	assert.NoError(t, err)
+}
+
+func TestWorker_ClosedWithFlush(t *testing.T) {
+	config := newConfig(t)
+	events := make(chan *docker.APIEvents, 1)
+	c := &mockCloudWatchEventsClient{
+		putEvents: make(chan *cloudwatchevents.PutEventsInput, 1),
+	}
+	w := &Worker{
+		config:     config,
+		events:     events,
+		cloudwatch: c,
+	}
+
+	events <- &docker.APIEvents{Type: "image", Action: "pull"}
+	close(events)
+
+	err := w.Run()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len((<-c.putEvents).Entries))
+}
+
+const testConfig = `{
+  "events": {
+    "image": {
+      "actions": {
+        "pull": {}
+      }
+    }
+  }
+}`
+
+func newConfig(t testing.TB) *config.Config {
+	config, err := config.Load(strings.NewReader(testConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return config
+}
+
+type mockCloudWatchEventsClient struct {
+	putEvents chan *cloudwatchevents.PutEventsInput
+}
+
+func (m *mockCloudWatchEventsClient) PutEvents(input *cloudwatchevents.PutEventsInput) (*cloudwatchevents.PutEventsOutput, error) {
+	m.putEvents <- input
+	return nil, nil
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/remind101/dockerdog/cloudwatch"
 	"github.com/remind101/dockerdog/config"
 	"github.com/remind101/dockerdog/datadog"
 	"github.com/remind101/dockerdog/log"
@@ -55,6 +56,14 @@ var (
 			return log.Watch(c.config, c.events, t)
 		}),
 	}
+	cmdCloudWatch = cli.Command{
+		Name:  "cloudwatch",
+		Usage: "Shuttle events to CloudWatch Events.",
+		Flags: []cli.Flag{},
+		Action: withContext(func(c *Context) error {
+			return cloudwatch.Watch(c.config, c.events)
+		}),
+	}
 )
 
 func main() {
@@ -69,6 +78,7 @@ func main() {
 	app.Commands = []cli.Command{
 		cmdDatadog,
 		cmdLog,
+		cmdCloudWatch,
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
This adds an output for shuttling Docker events off to CloudWatch Events, where they can be fanned out to other AWS services like SNS/SQS/Firehose/Redshift.

On a side note, this is opened against the `v2` branch. That branch re-purposes this repo to be a more general tool for forwarding docker events to external services (kinda like a "logspout" for docker events) rather than just being datadog only. I'm considering just bringing this project into https://github.com/remind101/logspout, so everything is together.